### PR TITLE
Support ticket systems with entirely digit ticket IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Git Auto Prefix (IntelliJ Plugin)
-Automatically set the jira issue key (of the current branch name) as prefix for the commit message
+Automatically set the issue key (of the current branch name) as prefix for the commit message
 
-**Important:** This plugin only works on branches created by Jira (or manually, with exactly the same naming as jira would use)
+**Important:** This plugin only works on issue keys with the Jira format (ABC-1234) and issue keys that consist entirely of digits (12345) 
 
 ## Installation
 Plugin can be downloaded whithin IntelliJ or on the Jetbrains [Plugin Site](https://plugins.jetbrains.com/plugin/14238-git-auto-prefix)
@@ -15,14 +15,15 @@ Plugin can be downloaded whithin IntelliJ or on the Jetbrains [Plugin Site](http
 ## Samples
 Following prefix for commit messages will automatically be generated:
 
-| Branch name                            	| Commit prefix (with delimiter) 	| Commit prefix (wrapped)
-|----------------------------------------	|---------------	                |---------------
-| main                                  	| no action     	                | no action
-| master                                 	| no action     	                | no action
-| bugfix/ABC-1234-app-not-working        	| ABC-1234:     	                | [ABC-1234]
-| feature/ABC-1234-app-not-working       	| ABC-1234:     	                | [ABC-1234]
-| release/ABC-1234-app-not-working       	| ABC-1234:     	                | [ABC-1234]
-| someOtherType/ABC-1234-app-not-working 	| ABC-1234:     	                | [ABC-1234]
-| ABC-1234-app-not-working               	| ABC-1234:     	                | [ABC-1234]
-| ABC-1234                               	| ABC-1234:     	                | [ABC-1234]
+| Branch name                            | Commit prefix (with delimiter) | Commit prefix (wrapped)
+|----------------------------------------|--------------------------------|---------------
+| main                                   | no action                      | no action
+| master                                 | no action                      | no action
+| bugfix/ABC-1234-app-not-working        | ABC-1234:                      | [ABC-1234]
+| feature/ABC-1234-app-not-working       | ABC-1234:                      | [ABC-1234]
+| release/ABC-1234-app-not-working       | ABC-1234:                      | [ABC-1234]
+| someOtherType/ABC-1234-app-not-working | ABC-1234:                      | [ABC-1234]
+| ABC-1234-app-not-working               | ABC-1234:                      | [ABC-1234]
+| ABC-1234                               | ABC-1234:                      | [ABC-1234]
+| 12345-app-not-working                  | 12345:                         | [12345]
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'ch.repnik'
-version '1.3.0'
+version '1.4.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/ch/repnik/intellij/CommitPrefixCheckinHandler.java
+++ b/src/main/java/ch/repnik/intellij/CommitPrefixCheckinHandler.java
@@ -1,7 +1,10 @@
 package ch.repnik.intellij;
 
+import static ch.repnik.intellij.settings.TicketSystem.JIRA;
+
 import ch.repnik.intellij.settings.PluginConfigService;
 import ch.repnik.intellij.settings.Position;
+import ch.repnik.intellij.settings.TicketSystem;
 import com.intellij.dvcs.DvcsUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -27,197 +30,219 @@ import java.util.regex.Pattern;
 
 public class CommitPrefixCheckinHandler extends CheckinHandler implements GitRepositoryChangeListener {
 
-    private final Logger log = Logger.getInstance(getClass());
-    private final CheckinProjectPanel panel;
-    private static final Pattern branchNamePattern = Pattern.compile("(?<=\\/)*([A-Z0-9]+-[0-9]+)");
-    private static final Pattern prefixPattern = Pattern.compile("[A-Z0-9]+-[0-9]+");
+  private final Logger log = Logger.getInstance(getClass());
+  private final CheckinProjectPanel panel;
+  private static final Pattern jiraBranchNamePattern =
+      Pattern.compile("(?<=\\/)*([A-Z0-9]+-[0-9]+)");
+  private static final Pattern otherBranchNamePattern = Pattern.compile("(?<=\\/)*(\\d+)");
+  private static final Pattern jiraPrefixPattern = Pattern.compile("[A-Z0-9]+-[0-9]+");
+  private static final Pattern otherPrefixPattern = Pattern.compile("\\d+");
 
-    public CommitPrefixCheckinHandler(CheckinProjectPanel panel) {
-        this.panel = panel;
+  public CommitPrefixCheckinHandler(CheckinProjectPanel panel) {
+    this.panel = panel;
 
-        MessageBusConnection connect = panel.getProject().getMessageBus().connect();
-        connect.subscribe(GitRepository.GIT_REPO_CHANGE, this);
+    MessageBusConnection connect = panel.getProject().getMessageBus().connect();
+    connect.subscribe(GitRepository.GIT_REPO_CHANGE, this);
 
-        //Sets the new message on the new commit UI
-        updateCommitMessage();
-    }
+    // Sets the new message on the new commit UI
+    updateCommitMessage();
+  }
 
-    private void updateCommitMessage(){
+  private void updateCommitMessage() {
         ApplicationManager.getApplication().invokeLater(() -> {
             PsiDocumentManager psiInstance = PsiDocumentManager.getInstance(this.panel.getProject());
-            if (psiInstance instanceof PsiDocumentManagerImpl){
-                if (!((PsiDocumentManagerImpl) psiInstance).isCommitInProgress()){
-                    panel.setCommitMessage(getNewCommitMessage());
-                }else{
+              if (psiInstance instanceof PsiDocumentManagerImpl) {
+                if (!((PsiDocumentManagerImpl) psiInstance).isCommitInProgress()) {
+                  panel.setCommitMessage(getNewCommitMessage());
+                } else {
                     log.info("PsiDocumentManager reported commit in progress. Skipping Git Auto Prefix");
                 }
-            }else{
+              } else {
                 log.info("PsiDocumentManager is not an instance of PsiDocumentManagerImpl. Skipping Git Auto Prefix");
-            }
-        });
+              }
+            });
+  }
+
+  @Nullable
+  @Override
+  public RefreshableOnComponent getBeforeCheckinConfigurationPanel() {
+    // Sets the new message on the old commit UI
+    updateCommitMessage();
+    return super.getBeforeCheckinConfigurationPanel();
+  }
+
+  private String getNewCommitMessage() {
+    String branchName = extractBranchName();
+    // log.warn("BranchName: " + branchName);
+
+    Optional<String> ticketName = getTicket(getTicketSystem(), branchName);
+
+    if (ticketName.isPresent()) {
+      // Sets the value for the new Panel UI
+      return updatePrefix(ticketName.get(), panel.getCommitMessage(), getTicketSystem(), getWrapLeft(), getWrapRight(), getIssueKeyPosition());
     }
 
-    @Nullable
-    @Override
-    public RefreshableOnComponent getBeforeCheckinConfigurationPanel() {
-        //Sets the new message on the old commit UI
-        updateCommitMessage();
-        return super.getBeforeCheckinConfigurationPanel();
+    return panel.getCommitMessage();
+  }
+
+  static Optional<String> getTicket(TicketSystem ticketSystem, String branchName) {
+    Pattern branchNamePattern =
+        ticketSystem == JIRA ? jiraBranchNamePattern : otherBranchNamePattern;
+    Matcher matcher = branchNamePattern.matcher(branchName);
+    if (matcher.find()){
+      return Optional.ofNullable(matcher.group(1));
+    }else{
+      return Optional.empty();
+    }
+  }
+
+  static String rTrim(String input) {
+    int i = input.length() - 1;
+    while (i >= 0 && Character.isWhitespace(input.charAt(i))) {
+      i--;
+    }
+    return input.substring(0, i + 1);
+  }
+
+  static String lTrim(String input) {
+    int i = 0;
+    while (i <= input.length() - 1 && Character.isWhitespace(input.charAt(i))) {
+      i++;
+    }
+    return input.substring(i, input.length());
+  }
+
+  static String updatePrefix(String newPrefix, String currentMessage, TicketSystem ticketSystem, String wrapLeft, String wrapRight, Position issueKeyPosition) {
+    if (currentMessage == null || currentMessage.trim().isEmpty()) {
+      return wrapLeft + newPrefix + wrapRight;
     }
 
-    private String getNewCommitMessage(){
-        String branchName = extractBranchName();
-        //log.warn("BranchName: " + branchName);
+    Pattern prefixPattern = ticketSystem == JIRA ? jiraPrefixPattern : otherPrefixPattern;
 
-        Optional<String> jiraTicketName = getJiraTicketName(branchName);
+    return updatePrefix(
+        newPrefix, currentMessage, wrapLeft, wrapRight, issueKeyPosition, prefixPattern);
+  }
 
-        if (jiraTicketName.isPresent()){
-            //Sets the value for the new Panel UI
-            return updatePrefix(jiraTicketName.get(), panel.getCommitMessage(), getWrapLeft(), getWrapRight(), getIssueKeyPosition());
-        }
+    private static String updatePrefix(String newPrefix, String currentMessage, String wrapLeft, String wrapRight,
+        Position issueKeyPosition, Pattern prefixPattern) {
+    // If there is already a commit message with a matching prefix only replace the prefix
+    Matcher matcher = prefixPattern.matcher(currentMessage);
+    Matcher foundLastMatch = null;
 
-        return  panel.getCommitMessage();
+    if (issueKeyPosition == Position.END) {
+      foundLastMatch = selectLastMatch(matcher, prefixPattern, currentMessage);
     }
-
-    static Optional<String> getJiraTicketName(String branchName){
-        Matcher matcher = branchNamePattern.matcher(branchName);
-        if (matcher.find()){
-            return Optional.ofNullable(matcher.group(1));
-        }else{
-            return Optional.empty();
-        }
-    }
-
-    static String rTrim(String input){
-        int i = input.length()-1;
-        while (i >= 0 && Character.isWhitespace(input.charAt(i))) {
-            i--;
-        }
-        return input.substring(0,i+1);
-    }
-
-    static String lTrim(String input){
-        int i = 0;
-        while (i <= input.length()-1 && Character.isWhitespace(input.charAt(i))) {
-            i++;
-        }
-        return input.substring(i,input.length());
-    }
-
-    static String updatePrefix(String newPrefix, String currentMessage, String wrapLeft, String wrapRight, Position issueKeyPosition){
-        if (currentMessage == null || currentMessage.trim().isEmpty()){
-            return wrapLeft + newPrefix + wrapRight;
-        }
-
-        //If there is already a commit message with a matching prefix only replace the prefix
-        Matcher matcher = prefixPattern.matcher(currentMessage);
-        Matcher foundLastMatch = null;
-
-        if (issueKeyPosition == Position.END){
-            foundLastMatch = selectLastMatch(matcher, prefixPattern, currentMessage);
-        }
 
         if (issueKeyPosition == Position.START && matcher.find() &&
-                subString(currentMessage,0, matcher.start()).trim().equals(wrapLeft) &&
-                (subString(currentMessage, matcher.end(), matcher.end() + wrapRight.length()).equals(wrapRight) ||
-                        subString(currentMessage, matcher.end(), matcher.end() + wrapRight.length()).equals(rTrim(wrapRight)))
+            subString(currentMessage,0, matcher.start()).trim().equals(wrapLeft) &&
+            (subString(currentMessage, matcher.end(), matcher.end() + wrapRight.length()).equals(
+                wrapRight) ||
+                subString(currentMessage, matcher.end(), matcher.end() + wrapRight.length()).equals(rTrim(
+                    wrapRight)))
         ){
-            String start = subString(currentMessage, 0, matcher.start());
-            String end = subString(currentMessage, matcher.end() + wrapRight.length());
+      String start = subString(currentMessage, 0, matcher.start());
+      String end = subString(currentMessage, matcher.end() + wrapRight.length());
 
-            return start + newPrefix + wrapRight + end;
+      return start + newPrefix + wrapRight + end;
         }else if (issueKeyPosition == Position.END && foundLastMatch.find() &&
-                subString(currentMessage,foundLastMatch.end(), currentMessage.length()).trim().equals(wrapRight) &&
-                (subString(currentMessage, foundLastMatch.start()-wrapLeft.length(), foundLastMatch.start()).equals(wrapLeft) ||
-                        subString(currentMessage, foundLastMatch.start()-wrapLeft.length(), foundLastMatch.start()).equals(lTrim(wrapLeft)))){
+            subString(currentMessage,foundLastMatch.end(), currentMessage.length()).trim().equals(
+                wrapRight) &&
+            (subString(currentMessage, foundLastMatch.start()- wrapLeft.length(), foundLastMatch.start()).equals(
+                wrapLeft) ||
+                subString(currentMessage, foundLastMatch.start()- wrapLeft.length(), foundLastMatch.start()).equals(lTrim(
+                    wrapLeft)))){
 
-            String start = subString(currentMessage, 0, foundLastMatch.start());
-            String end = subString(currentMessage, foundLastMatch.end() + wrapRight.length());
+      String start = subString(currentMessage, 0, foundLastMatch.start());
+      String end = subString(currentMessage, foundLastMatch.end() + wrapRight.length());
 
-            return start + newPrefix + wrapRight + end;
+      return start + newPrefix + wrapRight + end;
 
-        }
+    }
 
-        if (issueKeyPosition == Position.START){
-            return wrapLeft + newPrefix + wrapRight + currentMessage;
+    if (issueKeyPosition == Position.START) {
+      return wrapLeft + newPrefix + wrapRight + currentMessage;
         }
         else{
-            return currentMessage + wrapLeft + newPrefix + wrapRight;
-        }
+      return currentMessage + wrapLeft + newPrefix + wrapRight;
+    }
+  }
+
+  private static Matcher selectLastMatch(Matcher matcher, Pattern pattern, String input) {
+    int foundMatches = 0;
+    while (matcher.find()) {
+      foundMatches++;
     }
 
-    private static Matcher selectLastMatch(Matcher matcher, Pattern pattern, String input) {
-        int foundMatches = 0;
-        while (matcher.find()) {
-            foundMatches++;
-        }
+    Matcher newMatcher = pattern.matcher(input);
+    if (foundMatches > 1) {
+      for (int i = 1; i < foundMatches; i++) {
+        newMatcher.find();
+      }
 
-        Matcher newMatcher = pattern.matcher(input);
-        if (foundMatches > 1){
-            for (int i = 1; i<foundMatches; i++){
-                newMatcher.find();
-            }
-
-            return newMatcher;
-        }
-
-        return pattern.matcher(input);
+      return newMatcher;
     }
 
-    static String subString(String string, int start){
-        if (string.length() < start){
-            return "";
-        }else{
-            return string.substring(start);
-        }
-    }
+    return pattern.matcher(input);
+  }
 
-    static String subString(String string, int start, int end){
-        if (end < start){
-            throw new IllegalArgumentException("start must be smaller than end");
-        } else if (string.length() < start || start == end){
-            return "";
-        } else if (string.length() < end){
-            return string.substring(start);
-        } else {
-            return string.substring(start, end);
-        }
+  static String subString(String string, int start) {
+    if (string.length() < start) {
+      return "";
+    } else {
+      return string.substring(start);
     }
+  }
 
-    Position getIssueKeyPosition() {
+  static String subString(String string, int start, int end) {
+    if (end < start) {
+      throw new IllegalArgumentException("start must be smaller than end");
+    } else if (string.length() < start || start == end) {
+      return "";
+    } else if (string.length() < end) {
+      return string.substring(start);
+    } else {
+      return string.substring(start, end);
+    }
+  }
+
+  TicketSystem getTicketSystem() {
+    return this.panel.getProject().getService(PluginConfigService.class).getState().getTicketSystem();
+  }
+
+  Position getIssueKeyPosition() {
         return this.panel.getProject().getService(PluginConfigService.class).getState().getIssueKeyPosition();
-    }
+  }
 
-    String getWrapRight() {
-        return this.panel.getProject().getService(PluginConfigService.class).getState().getWrapRight();
-    }
+  String getWrapRight() {
+    return this.panel.getProject().getService(PluginConfigService.class).getState().getWrapRight();
+  }
 
-    String getWrapLeft() {
-        return this.panel.getProject().getService(PluginConfigService.class).getState().getWrapLeft();
-    }
+  String getWrapLeft() {
+    return this.panel.getProject().getService(PluginConfigService.class).getState().getWrapLeft();
+  }
 
-    private String extractBranchName() {
-        Project project = panel.getProject();
+  private String extractBranchName() {
+    Project project = panel.getProject();
 
-        String branch = "";
-        ProjectLevelVcsManager instance = ProjectLevelVcsManagerImpl.getInstance(project);
-        if (instance.checkVcsIsActive("Git")) {
+    String branch = "";
+    ProjectLevelVcsManager instance = ProjectLevelVcsManagerImpl.getInstance(project);
+    if (instance.checkVcsIsActive("Git")) {
             GitRepository currentRepository = GitBranchUtil.guessWidgetRepository(project, DvcsUtil.getSelectedFile(project));
-            if (currentRepository != null) {
-                GitLocalBranch currentBranch = currentRepository.getCurrentBranch();
+      if (currentRepository != null) {
+        GitLocalBranch currentBranch = currentRepository.getCurrentBranch();
 
-                if (currentBranch != null) {
-                    // Branch name  matches Ticket Name
-                    branch = currentBranch.getName().trim();
-                }
-            }
+        if (currentBranch != null) {
+          // Branch name  matches Ticket Name
+          branch = currentBranch.getName().trim();
         }
-
-        return branch;
+      }
     }
 
-    @Override
-    public void repositoryChanged(@NotNull GitRepository repository) {
-        updateCommitMessage();
-    }
+    return branch;
+  }
+
+  @Override
+  public void repositoryChanged(@NotNull GitRepository repository) {
+    updateCommitMessage();
+  }
 }

--- a/src/main/java/ch/repnik/intellij/settings/PluginConfigService.java
+++ b/src/main/java/ch/repnik/intellij/settings/PluginConfigService.java
@@ -35,10 +35,18 @@ public class PluginConfigService implements PersistentStateComponent<PluginConfi
 
     public static class Configuration implements Serializable {
 
+        private TicketSystem ticketSystem = TicketSystem.JIRA;
         private String wrapLeft = "";
         private String wrapRight = ": ";
-
         private Position issueKeyPosition = Position.START;
+
+        public TicketSystem getTicketSystem() {
+            return ticketSystem;
+        }
+
+        public void setTicketSystem(TicketSystem ticketSystem) {
+            this.ticketSystem = ticketSystem;
+        }
 
         public String getWrapLeft() {
             return wrapLeft;

--- a/src/main/java/ch/repnik/intellij/settings/PluginSettingsForm.form
+++ b/src/main/java/ch/repnik/intellij/settings/PluginSettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="ch.repnik.intellij.settings.PluginSettingsForm">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="6" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <component id="46d34" class="javax.swing.JLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Wrap Left"/>
@@ -18,7 +18,7 @@
       </component>
       <component id="fcb65" class="javax.swing.JTextField" binding="txtWrapLeft">
         <constraints>
-          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="60" height="-1"/>
           </grid>
         </constraints>
@@ -28,12 +28,12 @@
       </component>
       <hspacer id="936a0">
         <constraints>
-          <grid row="0" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="5" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
       <component id="8566f" class="javax.swing.JLabel">
         <constraints>
-          <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font size="10" style="2"/>
@@ -42,7 +42,7 @@
       </component>
       <component id="d413e" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="129" height="32"/>
           </grid>
         </constraints>
@@ -52,12 +52,12 @@
       </component>
       <vspacer id="baff5">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="d968b" class="javax.swing.JTextField" binding="txtWrapRight">
         <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="60" height="32"/>
           </grid>
         </constraints>
@@ -67,7 +67,7 @@
       </component>
       <component id="ddc97" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="52" height="32"/>
           </grid>
         </constraints>
@@ -78,7 +78,7 @@
       </component>
       <component id="a591f" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="129" height="32"/>
           </grid>
         </constraints>
@@ -89,7 +89,7 @@
       </component>
       <component id="40aa7" class="javax.swing.JComboBox" binding="cboPosition">
         <constraints>
-          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <model>
@@ -100,13 +100,43 @@
       </component>
       <component id="f7674" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="52" height="32"/>
           </grid>
         </constraints>
         <properties>
           <font size="10" style="2"/>
           <text value="Default: start"/>
+        </properties>
+      </component>
+      <component id="1e681" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Ticket system"/>
+        </properties>
+      </component>
+      <component id="d2105" class="javax.swing.JComboBox" binding="cboTicketSystem">
+        <constraints>
+          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <model>
+            <item value="Jira (ABC-1234)"/>
+            <item value="Other (12345)"/>
+          </model>
+        </properties>
+      </component>
+      <component id="4ac1b" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="52" height="32"/>
+          </grid>
+        </constraints>
+        <properties>
+          <font size="10" style="2"/>
+          <text value="Default: Jira"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/ch/repnik/intellij/settings/PluginSettingsForm.java
+++ b/src/main/java/ch/repnik/intellij/settings/PluginSettingsForm.java
@@ -24,7 +24,7 @@ public class PluginSettingsForm extends BaseConfigurable implements SearchableCo
 
     private Project project;
 
-    private Pattern allowedCharsPattern = Pattern.compile("[ \\[\\]\\(\\)\\{\\}:\\_\\-/\\|,\\.]+");
+    private Pattern allowedCharsPattern = Pattern.compile("[ \\[\\]\\(\\)\\{\\}:\\_\\-/\\|,\\.#]+");
 
 
     public PluginSettingsForm(Project project){
@@ -121,11 +121,11 @@ public class PluginSettingsForm extends BaseConfigurable implements SearchableCo
         }
 
         if (!allowedCharsPattern.matcher(getWrapRight()).matches()){
-            throw new ConfigurationException("Wrap Right/Delimiter can only contain following chars: \" [](){}:_-/|,.\"", "Validation failed");
+            throw new ConfigurationException("Wrap Right/Delimiter can only contain following chars: \" [](){}:_-/|,.#\"", "Validation failed");
         }
 
         if (!getWrapLeft().isEmpty() && !allowedCharsPattern.matcher(getWrapLeft()).matches()){
-            throw new ConfigurationException("Wrap Left can only contain following chars: \" [](){}:_-/|,.\"", "Validation failed");
+            throw new ConfigurationException("Wrap Left can only contain following chars: \" [](){}:_-/|,.#\"", "Validation failed");
         }
     }
 

--- a/src/main/java/ch/repnik/intellij/settings/PluginSettingsForm.java
+++ b/src/main/java/ch/repnik/intellij/settings/PluginSettingsForm.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 
 public class PluginSettingsForm extends BaseConfigurable implements SearchableConfigurable {
     private JPanel mainPanel;
+    private JComboBox cboTicketSystem;
     private JTextField txtWrapLeft;
     private JTextField txtWrapRight;
     private JComboBox cboPosition;
@@ -48,6 +49,10 @@ public class PluginSettingsForm extends BaseConfigurable implements SearchableCo
         return mainPanel;
     }
 
+    public TicketSystem getTicketSystem() {
+        return TicketSystem.parse(cboTicketSystem.getSelectedItem().toString());
+    }
+
     public String getWrapRight(){
         return txtWrapRight.getText();
     }
@@ -59,6 +64,7 @@ public class PluginSettingsForm extends BaseConfigurable implements SearchableCo
     }
 
     public void resetEditorFrom(PluginConfigService settings){
+        this.cboTicketSystem.setSelectedItem(settings.getState().getTicketSystem().getDescription());
         this.txtWrapLeft.setText(settings.getState().getWrapLeft());
         this.txtWrapRight.setText(settings.getState().getWrapRight());
         this.cboPosition.setSelectedItem(settings.getState().getIssueKeyPosition().getStringValue());
@@ -82,13 +88,15 @@ public class PluginSettingsForm extends BaseConfigurable implements SearchableCo
     @Override
     public boolean isModified() {
         PluginConfigService.Configuration state = project.getService(PluginConfigService.class).getState();
+        TicketSystem oldTicketSystem = state.getTicketSystem();
+        TicketSystem newTicketSystem = getTicketSystem();
         String oldValueRight = state.getWrapRight();
         String newValueRight = getWrapRight();
         String oldValueLeft = state.getWrapLeft();
         String newValueLeft = getWrapRight();
         Position oldIssueKeyPosition = state.getIssueKeyPosition();
         Position newIssueKeyPosition = getIssueKeyPosition();
-        return !Objects.equals(oldValueRight, newValueRight) || !Objects.equals(oldValueLeft, newValueLeft) || oldIssueKeyPosition != newIssueKeyPosition;
+        return oldTicketSystem != newTicketSystem || !Objects.equals(oldValueRight, newValueRight) || !Objects.equals(oldValueLeft, newValueLeft) || oldIssueKeyPosition != newIssueKeyPosition;
     }
 
     @Override
@@ -98,6 +106,7 @@ public class PluginSettingsForm extends BaseConfigurable implements SearchableCo
                 validate();
                 System.out.println("Config applied");
                 PluginConfigService.Configuration state = project.getService(PluginConfigService.class).getState();
+                state.setTicketSystem(getTicketSystem());
                 state.setWrapRight(getWrapRight());
                 state.setWrapLeft(getWrapLeft());
                 state.setIssueKeyPosition(getIssueKeyPosition());

--- a/src/main/java/ch/repnik/intellij/settings/TicketSystem.java
+++ b/src/main/java/ch/repnik/intellij/settings/TicketSystem.java
@@ -1,0 +1,25 @@
+package ch.repnik.intellij.settings;
+
+import java.util.Arrays;
+
+public enum TicketSystem {
+  JIRA("Jira (ABC-1234)"),OTHER("Other (12345)");
+
+  private final String description;
+
+  TicketSystem(String description) {
+    this.description = description;
+  }
+
+  public String getDescription() {
+    return this.description;
+  }
+
+  public static TicketSystem parse(String description) {
+    return Arrays.stream(TicketSystem.values())
+        .filter(ticketSystem -> ticketSystem.getDescription().equals(description))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Description '" + description + "' was not found in enum"));
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>commit-prefix-plugin</id>
     <name>Git Auto Prefix</name>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <vendor url="https://github.com/thomasrepnik/idea-commit-prefix-plugin">Thomas Repnik</vendor>
 
     <change-notes><![CDATA[

--- a/src/test/java/ch/repnik/intellij/CommitPrefixCheckinHandlerTest.java
+++ b/src/test/java/ch/repnik/intellij/CommitPrefixCheckinHandlerTest.java
@@ -10,251 +10,406 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 class CommitPrefixCheckinHandlerTest {
 
-    @Test
-    public void updatePrefix_noMatchPositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "Testli", ": ",  "", Position.END);
-        assertThat(result, is("Testli: ABC-1234"));
+  @Test
+  public void updatePrefix_noMatchPositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("Testli")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage("Testli: ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_existingMessage_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("XYXY-837292: This is my text")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234: This is my text");
+  }
+
+  @Test
+  public void updatePrefix_existingMessagePositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("This is my text: XYXY-837292")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage("This is my text: ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_delimiterWithoutMessage_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("XYXY-837292:")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234: ");
+  }
+
+  @Test
+  public void updatePrefix_delimiterWithoutMessagePositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(": XYXY-837292")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage(": ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_wrongDelimiter_issueNotRecognized() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("XYXY-837292: This is my text")
+        .withPluginSettings("", " | ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234 | XYXY-837292: This is my text");
+  }
+
+  @Test
+  public void updatePrefix_wrongDelimiterPositionEnd_issueNotRecognized() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("This is my text: XYXY-837292")
+        .withPluginSettings(" | ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage("This is my text: XYXY-837292 | ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_specialDelimiter_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings(" [](){}:_-/|,.", " [](){}:_-/|,.", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage(" [](){}:_-/|,.ABC-1234 [](){}:_-/|,.");
+  }
+
+  @Test
+  public void updatePrefix_specialDelimiterPositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings(" [](){}:_-/|,.", " [](){}:_-/|,.", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage(" [](){}:_-/|,.ABC-1234 [](){}:_-/|,.");
+  }
+
+  @Test
+  public void updatePrefix_doubledPattern_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("XYXY-837292: XYZ-11 This is my text")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234: XYZ-11 This is my text");
+  }
+
+  @Test
+  public void updatePrefix_doubledPatternPositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("XYZ-11 This is my text: XYXY-837292")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage("XYZ-11 This is my text: ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_null_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234: ");
+  }
+
+  @Test
+  public void updatePrefix_nullPositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage(": ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_emptyMessage_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234: ");
+  }
+
+  @Test
+  public void updatePrefix_emptyMessagePositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage(": ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_blankMessage_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("       ")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234: ");
+  }
+
+  @Test
+  public void updatePrefix_blankMessagePositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("       ")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage(": ABC-1234");
+  }
+
+  @Test
+  public void updatePrefix_existingMessageWithBlanks_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("   XYXY-837292:  This is a Test     ")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("   ABC-1234:  This is a Test     ");
+  }
+
+  @Test
+  public void updatePrefix_existingMessageWithBlanksPositionEnd_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("   This is a Test  : XYXY-837292     ")
+        .withPluginSettings(": ", "", Position.END)
+        .updatePrefix()
+        .shouldHaveNewMessage("   This is a Test  : ABC-1234     ");
+  }
+
+  @Test
+  public void updatePrefix_existingMessageWithPrefixInText_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("   According to issue XYXY-837292: this fix...     ")
+        .withPluginSettings("", ": ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("ABC-1234:    According to issue XYXY-837292: this fix...     ");
+  }
+
+  // TESTS WITH WRAP LEFT
+
+  @Test
+  public void updatePrefix_existingMessageWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("[XYXY-837292]: This is my text")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]: This is my text");
+  }
+
+  @Test
+  public void updatePrefix_delimiterWithoutMessageWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("[XYXY-837292]:")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]: ");
+  }
+
+  @Test
+  public void updatePrefix_wrongDelimiterWrapLeft_issueNotRecognized() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("[XYXY-837292]: This is my text")
+        .withPluginSettings("[", " | ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234 | [XYXY-837292]: This is my text");
+  }
+
+  @Test
+  public void updatePrefix_specialDelimiterWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings(" [](){}:_-/|,.", " [](){}:_-/|,.", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage(" [](){}:_-/|,.ABC-1234 [](){}:_-/|,.");
+  }
+
+  @Test
+  public void updatePrefix_doubledPatternWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("[XYXY-837292]: XYZ-11 This is my text")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]: XYZ-11 This is my text");
+  }
+
+  @Test
+  public void updatePrefix_nullWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]: ");
+  }
+
+  @Test
+  public void updatePrefix_emptyMessageWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]: ");
+  }
+
+  @Test
+  public void updatePrefix_blankMessageWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("       ")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]: ");
+  }
+
+  @Test
+  public void updatePrefix_existingMessageWithBlanksWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("   [XYXY-837292]:  This is a Test     ")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("   [ABC-1234]:  This is a Test     ");
+  }
+
+  @Test
+  public void updatePrefix_existingMessageWithPrefixInTextWrapLeft_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage("   According to issue XYXY-837292: this fix...     ")
+        .withPluginSettings("[", "]: ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("[ABC-1234]:    According to issue XYXY-837292: this fix...     ");
+  }
+
+  @Test
+  public void updatePrefix_noMessageButWrappedInBlanks_updatedCorrectly() {
+    updateABC1234JiraPrefixTester()
+        .withCurrentMessage(null)
+        .withPluginSettings("     ", "     ", Position.START)
+        .updatePrefix()
+        .shouldHaveNewMessage("     ABC-1234     ");
+  }
+
+  private static UpdatePrefixTester updateABC1234JiraPrefixTester() {
+    return new UpdatePrefixTester().withNewPrefix("ABC-1234");
+  }
+
+  static class UpdatePrefixTester {
+
+    private String currentMessage;
+    private String newPrefix;
+    private String wrapLeft;
+    private String wrapRight;
+    private Position issueKeyPosition;
+
+    UpdatePrefixTester() {}
+
+    UpdatePrefixTester withCurrentMessage(String currentMessage) {
+      this.currentMessage = currentMessage;
+      return this;
     }
 
-    @Test
-    public void updatePrefix_existingMessage_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "XYXY-837292: This is my text", "",  ": ", Position.START);
-        assertThat(result, is("ABC-1234: This is my text"));
+    UpdatePrefixTester withNewPrefix(String newPrefix) {
+      this.newPrefix = newPrefix;
+      return this;
     }
 
-    @Test
-    public void updatePrefix_existingMessagePositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "This is my text: XYXY-837292", ": ",  "", Position.END);
-        assertThat(result, is("This is my text: ABC-1234"));
+    UpdatePrefixTester withPluginSettings(
+        String wrapLeft, String wrapRight, Position issueKeyPosition) {
+      this.wrapLeft = wrapLeft;
+      this.wrapRight = wrapRight;
+      this.issueKeyPosition = issueKeyPosition;
+      return this;
     }
 
-    @Test
-    public void updatePrefix_delimiterWithoutMessage_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "XYXY-837292:","", ": ", Position.START);
-        assertThat(result, is("ABC-1234: "));
+    UpdatePrefixAsserter updatePrefix() {
+      var newMessage =
+          CommitPrefixCheckinHandler.updatePrefix(
+              newPrefix, currentMessage, wrapLeft, wrapRight, issueKeyPosition);
+      return new UpdatePrefixAsserter(newMessage);
+    }
+  }
+
+  static class UpdatePrefixAsserter {
+
+    private final String actualMessage;
+
+    UpdatePrefixAsserter(String actualMessage) {
+      this.actualMessage = actualMessage;
     }
 
-    @Test
-    public void updatePrefix_delimiterWithoutMessagePositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", ": XYXY-837292",": ", "", Position.END);
-        assertThat(result, is(": ABC-1234"));
+    void shouldHaveNewMessage(String expectedMessage) {
+      assertThat(actualMessage, is(expectedMessage));
+    }
+  }
+
+  @Test
+  public void getJiraTicketName_withoutBranchType_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("ABC-1234-app-not-working")
+        .shouldHaveTicketName("ABC-1234");
+  }
+
+  @Test
+  public void getJiraTicketName_reproduce() {
+    TicketNameTester.getTicketNameFromBranch("feature/DATA-4214-ab-CEP3.0-Transition-polling")
+        .shouldHaveTicketName("DATA-4214");
+  }
+
+  @Test
+  public void getJiraTicketName_featureBranchType_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("feature/ABC-1234-app-not-working")
+        .shouldHaveTicketName("ABC-1234");
+  }
+
+  @Test
+  public void getJiraTicketName_releaseBranchType_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("release/ABC-1234-app-not-working")
+        .shouldHaveTicketName("ABC-1234");
+  }
+
+  @Test
+  public void getJiraTicketName_bugfixBranchType_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("bugfix/ABC-1234-app-not-working")
+        .shouldHaveTicketName("ABC-1234");
+  }
+
+  @Test
+  public void getJiraTicketName_someOtherType_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("someOtherType/ABC-1234-app-not-working")
+        .shouldHaveTicketName("ABC-1234");
+  }
+
+  @Test
+  public void getJiraTicketName_emptyType_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("/ABC-1234-app-not-working")
+        .shouldHaveTicketName("ABC-1234");
+  }
+
+  @Test
+  public void getJiraTicketName_emptySuffix_retunsJiraTicket() {
+    TicketNameTester.getTicketNameFromBranch("feature/ABC-1234").shouldHaveTicketName("ABC-1234");
+  }
+
+  static class TicketNameTester {
+
+    static TicketNameAsserter getTicketNameFromBranch(String branchName) {
+      var ticketName = CommitPrefixCheckinHandler.getJiraTicketName(branchName);
+      return new TicketNameAsserter(ticketName);
+    }
+  }
+
+  static class TicketNameAsserter {
+
+    private final Optional<String> actualTicketName;
+
+    TicketNameAsserter(Optional<String> actualTicketName) {
+      this.actualTicketName = actualTicketName;
     }
 
-    @Test
-    public void updatePrefix_wrongDelimiter_issueNotRecognized() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "XYXY-837292: This is my text","", " | ", Position.START);
-        assertThat(result, is("ABC-1234 | XYXY-837292: This is my text"));
+    void shouldHaveTicketName(String expectedTicketName) {
+      assertThat(actualTicketName.isPresent(), is(true));
+      assertThat(actualTicketName.get(), is(expectedTicketName));
     }
-
-    @Test
-    public void updatePrefix_wrongDelimiterPositionEnd_issueNotRecognized() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "This is my text: XYXY-837292"," | ", "", Position.END);
-        assertThat(result, is("This is my text: XYXY-837292 | ABC-1234"));
-    }
-
-    @Test
-    public void updatePrefix_specialDelimiter_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null," [](){}:_-/|,.", " [](){}:_-/|,.", Position.START);
-        assertThat(result, is(" [](){}:_-/|,.ABC-1234 [](){}:_-/|,."));
-    }
-
-    @Test
-    public void updatePrefix_specialDelimiterPositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null," [](){}:_-/|,.", " [](){}:_-/|,.", Position.END);
-        assertThat(result, is(" [](){}:_-/|,.ABC-1234 [](){}:_-/|,."));
-    }
-
-    @Test
-    public void updatePrefix_doubledPattern_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "XYXY-837292: XYZ-11 This is my text","", ": ", Position.START);
-        assertThat(result, is("ABC-1234: XYZ-11 This is my text"));
-    }
-
-    @Test
-    public void updatePrefix_doubledPatternPositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "XYZ-11 This is my text: XYXY-837292",": ", "", Position.END);
-        assertThat(result, is("XYZ-11 This is my text: ABC-1234"));
-    }
-
-    @Test
-    public void updatePrefix_null_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null,"", ": ", Position.START);
-        assertThat(result, is("ABC-1234: "));
-    }
-
-    @Test
-    public void updatePrefix_nullPositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null,": ", "", Position.END);
-        assertThat(result, is(": ABC-1234"));
-    }
-
-    @Test
-    public void updatePrefix_emptyMessage_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "","", ": ", Position.START);
-        assertThat(result, is("ABC-1234: "));
-    }
-
-    @Test
-    public void updatePrefix_emptyMessagePositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "",": ", "", Position.END);
-        assertThat(result, is(": ABC-1234"));
-    }
-
-    @Test
-    public void updatePrefix_blankMessage_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "       ","", ": ", Position.START);
-        assertThat(result, is("ABC-1234: "));
-    }
-
-    @Test
-    public void updatePrefix_blankMessagePositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "       ",": ", "", Position.END);
-        assertThat(result, is(": ABC-1234"));
-    }
-
-    @Test
-    public void updatePrefix_existingMessageWithBlanks_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "   XYXY-837292:  This is a Test     ","", ": ", Position.START);
-        assertThat(result, is("   ABC-1234:  This is a Test     "));
-    }
-
-    @Test
-    public void updatePrefix_existingMessageWithBlanksPositionEnd_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "   This is a Test  : XYXY-837292     ",": ", "", Position.END);
-        assertThat(result, is("   This is a Test  : ABC-1234     "));
-    }
-
-    @Test
-    public void updatePrefix_existingMessageWithPrefixInText_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "   According to issue XYXY-837292: this fix...     ","", ": ", Position.START);
-        assertThat(result, is("ABC-1234:    According to issue XYXY-837292: this fix...     "));
-    }
-
-
-
-    //TESTS WITH WRAP LEFT
-    @Test
-    public void updatePrefix_existingMessageWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "[XYXY-837292]: This is my text", "[",  "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]: This is my text"));
-    }
-
-    @Test
-    public void updatePrefix_delimiterWithoutMessageWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "[XYXY-837292]:","[", "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]: "));
-    }
-
-    @Test
-    public void updatePrefix_wrongDelimiterWrapLeft_issueNotRecognized() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "[XYXY-837292]: This is my text","[", " | ", Position.START);
-        assertThat(result, is("[ABC-1234 | [XYXY-837292]: This is my text"));
-    }
-
-    @Test
-    public void updatePrefix_specialDelimiterWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null," [](){}:_-/|,.", " [](){}:_-/|,.", Position.START);
-        assertThat(result, is(" [](){}:_-/|,.ABC-1234 [](){}:_-/|,."));
-    }
-
-    @Test
-    public void updatePrefix_doubledPatternWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "[XYXY-837292]: XYZ-11 This is my text","[", "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]: XYZ-11 This is my text"));
-    }
-
-    @Test
-    public void updatePrefix_nullWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null,"[", "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]: "));
-    }
-
-    @Test
-    public void updatePrefix_emptyMessageWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "","[", "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]: "));
-    }
-
-    @Test
-    public void updatePrefix_blankMessageWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "       ","[", "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]: "));
-    }
-
-    @Test
-    public void updatePrefix_existingMessageWithBlanksWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "   [XYXY-837292]:  This is a Test     ","[", "]: ", Position.START);
-        assertThat(result, is("   [ABC-1234]:  This is a Test     "));
-    }
-
-    @Test
-    public void updatePrefix_existingMessageWithPrefixInTextWrapLeft_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", "   According to issue XYXY-837292: this fix...     ","[", "]: ", Position.START);
-        assertThat(result, is("[ABC-1234]:    According to issue XYXY-837292: this fix...     "));
-    }
-
-    @Test
-    public void updatePrefix_noMessageButWrappedInBlanks_updatedCorrectly() {
-        String result = CommitPrefixCheckinHandler.updatePrefix("ABC-1234", null,"     ", "     ", Position.START);
-        assertThat(result, is("     ABC-1234     "));
-    }
-
-    @Test
-    public void getJiraTicketName_withoutBranchType_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("ABC-1234-app-not-working");
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
-    @Test
-    public void getJiraTicketName_reproduce() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("feature/DATA-4214-ab-CEP3.0-Transition-polling");
-
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("DATA-4214"));
-    }
-
-    @Test
-    public void getJiraTicketName_featureBranchType_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("feature/ABC-1234-app-not-working");
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
-    @Test
-    public void getJiraTicketName_releaseBranchType_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("release/ABC-1234-app-not-working");
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
-    @Test
-    public void getJiraTicketName_bugfixBranchType_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("bugfix/ABC-1234-app-not-working");
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
-    @Test
-    public void getJiraTicketName_someOtherType_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("someOtherType/ABC-1234-app-not-working");
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
-    @Test
-    public void getJiraTicketName_emptyType_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("/ABC-1234-app-not-working");
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
-    @Test
-    public void getJiraTicketName_emptySuffix_retunsJiraTicket() {
-        Optional<String> result = CommitPrefixCheckinHandler.getJiraTicketName("feature/ABC-1234");
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get(), is("ABC-1234"));
-    }
-
+  }
 }


### PR DESCRIPTION
This change adds support for ticket systems with entirely digit ticket IDs.

A new _Ticket system_ setting was required because the Jira project key may consist entirely of digits. For example, ABC-1234 is a valid Jira ticket ID, but 123-1234 is as well. Supporting both that and entirely digit ticket IDs simultaneously could obviously lead to issues.

Additionally, a change was done to allow the #-sign in the wrap left and right. This is useful specifically for Azure Devops functionality and allowing it seemed to have no downsides.